### PR TITLE
Identify and flag HTML5 unary elements even without the /> token

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ var htmlParser = require('html-parser');
 var html = '<!doctype html><html><body onload="alert(\'hello\');">Hello<br />world</body></html>';
 htmlParser.parse(html, {
 	openElement: function(name) { console.log('open: %s', name); },
-	closeOpenedElement: function(name, token) { console.log('close token: %s', token); },
+	closeOpenedElement: function(name, token, unary) { console.log('token: %s, unary: %s', token, unary); },
 	closeElement: function(name) { console.log('close: %s', name); },
 	comment: function(value) { console.log('comment: %s', value); },
 	cdata: function(value) { console.log('cdata: %s', value); },
@@ -42,7 +42,7 @@ attribute: onload=alert('hello');
 close token: >
 text: Hello
 open: br
-close token: />
+close token: />, unary: true
 text: world
 close: body
 close: html

--- a/src/parser.js
+++ b/src/parser.js
@@ -40,21 +40,27 @@ function readAttributes(context, isXml) {
 }
 
 function readCloserForOpenedElement(context, name) {
+    var unary;
+    var emptyElements = { 'area': true, 'base': true, 'basefont': true, 'br': true, 'col': true, 'frame':   true, 'hr': true, 'img': true, 'input': true, 'isindex': true, 'link': true, 'meta': true, 'param': true, 'e  mbed': true }
+    if (name in emptyElements) {
+      unary = true;
+    }
+
 	if (context.current === '/') {
 		//self closing tag "/>"
 		context.readUntilNonWhitespace();
 		context.read();
-		context.callbacks.closeOpenedElement(name, '/>');
+		context.callbacks.closeOpenedElement(name, '/>', unary);
 	}
 	else if (context.current === '?') {
 		//xml closing "?>"
 		context.read(2);
-		context.callbacks.closeOpenedElement(name, '?>');
+		context.callbacks.closeOpenedElement(name, '?>', unary);
 	}
 	else {
 		//normal closing ">"
 		context.read();
-		context.callbacks.closeOpenedElement(name, '>');
+		context.callbacks.closeOpenedElement(name, '>', unary);
 	}
 }
 
@@ -195,8 +201,9 @@ function parseNext(context) {
  * @param {Object} [callbacks] Callbacks for each token
  * @param {Function} [callbacks.attribute] Takes the name of the attribute and its value
  * @param {Function} [callbacks.openElement] Takes the tag name of the element
- * @param {Function} [callbacks.closeOpenedElement] Takes the tag name of the element and the token used to
- * close it (">", "/>", "?>")
+ * @param {Function} [callbacks.closeOpenedElement] Takes the tag name of the element, the token used to
+ * close it (">", "/>", "?>") and a boolean telling if it is unary or not (i.e., if it doesn't requires
+ * another tag closing it later)
  * @param {Function} [callbacks.closeElement] Takes the name of the element
  * @param {Function} [callbacks.comment] Takes the content of the comment
  * @param {Function} [callbacks.docType] Takes the content of the document type declaration

--- a/tests/open-and-close-tag-tests.js
+++ b/tests/open-and-close-tag-tests.js
@@ -31,6 +31,14 @@ describe('opening and closing tags', function() {
 		closeCount.should.equal(1);
 	});
 
+	it('unary html5 element should be signalized as unary', function() {
+		helpers.parseString('<input>', {
+            closeOpenedElement: function(name, token, unary) {
+                unary.should.be.ok;
+            }
+		});
+	});
+
 	it('tag names can start with _', function() {
 		var openCount = 0, closeCount = 0;
 		helpers.parseString('<_foo></_foo>', {


### PR DESCRIPTION
For someone trying to use this parser to change the structure of the HTML in some way, this is very important.
