### PR TITLE
parse dots in tag name

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1,5 +1,5 @@
 var parseContext = require('./context');
-var nameRegex = /[a-zA-Z_][\w:-]*/;
+var nameRegex = /[a-zA-Z_][\w:\-\.]*/;
 
 function readAttribute(context) {
 	var name = context.readRegex(nameRegex);


### PR DESCRIPTION
I don't know is it standard or not but all editors is okay with dots in tags names.

I need it for my react project
