### PR TITLE
Public api for regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,11 @@ console.log(sanitized);
  * @param {Function} [callbacks.cdata] Takes the content of the CDATA
  * @param {Function} [callbacks.xmlProlog] Takes no arguments
  * @param {Function} [callbacks.text] Takes the value of the text node
+ * @param {Object} [regex]
+ * @param {RegExp} [regex.name] Regex for element name. Default is [a-zA-Z_][\w:\-\.]*
+ * @param {RegExp} [regex.attribute] Regex for attribute name. Default is [a-zA-Z_][\w:\-\.]*
  */
-parse(htmlString, callbacks)
+parse(htmlString, callbacks, regex)
 
 /**
  * Parses the HTML contained in the given file asynchronously.

--- a/src/context.js
+++ b/src/context.js
@@ -1,4 +1,4 @@
-exports.create = function(raw, options) {
+exports.create = function(raw, options, regex) {
 	var index = 0;
 	var context = {
 		text: '',
@@ -78,5 +78,16 @@ exports.create = function(raw, options) {
 		};
 	});
 
+	context.regex = {
+		name: /[a-zA-Z_][\w:\-\.]*/,
+		attribute: /[a-zA-Z_][\w:\-\.]*/
+	};
+	regex = regex || {};
+	for (var name in regex) {
+		if (regex.hasOwnProperty(name)) {
+			context.regex[name] = regex[name];
+		}
+	}
+
 	return context;
-}
+};

--- a/tests/attribute-tests.js
+++ b/tests/attribute-tests.js
@@ -172,4 +172,25 @@ describe('attributes', function() {
 		openCount.should.equal(1);
 		attrCount.should.equal(1);
 	});
+
+	it('with custom attribute regex', function() {
+		var openCount = 0, attrCount = 0;
+		helpers.parseString('<foo [bar]="baz">', {
+			openElement: function(name) {
+				name.should.equal('foo');
+				openCount++;
+			},
+
+			attribute: function(name, value) {
+				name.should.equal('[bar]');
+				value.should.equal('baz');
+				attrCount++;
+			}
+		}, {
+			attribute: /\[[\w\]]*/
+		});
+
+		openCount.should.equal(1);
+		attrCount.should.equal(1);
+	});
 });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -2,6 +2,6 @@ var htmlParser = require('../src/parser.js');
 
 exports.parser = htmlParser;
 
-exports.parseString = function(string, options) {
-	htmlParser.parse(string, options);
+exports.parseString = function(string, options, regex) {
+	htmlParser.parse(string, options, regex);
 };


### PR DESCRIPTION
How about to make all regex public? For example in angular 2 in attributes names they will use brackets and with current regex they will be ignored. I added config for regex as third parameter.  