### PR TITLE
Parse data elements like <% ... %>

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,40 @@ console.log(sanitized);
 //<p>blah blah</p>
 ```
 
+### Custom data elements
+You can parser custom data elements like php code or underscore templates with `regex.dataElements` config
+```javascript
+helpers.parseString('<div><?= "<div>$var</div>" ?></div>', {
+    openElement: function(name) {
+        console.log(name); // 'div'
+    },
+    closeElement: function(name) {
+        console.log(name); // 'div'
+    },
+    phpEcho: function(value) {
+        console.log(value); // {length: 61, someProperty: ' "<div>$var</div>" '}
+    }
+}, {
+    dataElements: {
+        phpEcho: {
+            start: '<?=',
+            data: function (string) {
+                var index = string.indexOf('?>'),
+                    code = string.slice(0, index);
+
+                return code;
+                // or
+                return {
+                    length: code.length, // required field
+                    someProperty: code
+                };
+            },
+            end: '?>'
+        }
+    }
+});
+```
+
 ## API
 ```javascript
 /**
@@ -105,8 +139,16 @@ console.log(sanitized);
  * @param {Object} [regex]
  * @param {RegExp} [regex.name] Regex for element name. Default is [a-zA-Z_][\w:\-\.]*
  * @param {RegExp} [regex.attribute] Regex for attribute name. Default is [a-zA-Z_][\w:\-\.]*
+ * @param {Object.<callbackName,DataElementConfig>} [regex.dataElements] Config of data elements like docType, comment and your own custom data elements
  */
 parse(htmlString, callbacks, regex)
+
+/**
+ * @typedef {Object} DataElementConfig
+ * @property {String|RegExp|Function} start - start of data element, for example '<%' or /^<\?=/ or function(string){return string.slice(0, 2) === '<%' ? 2 : -1;}
+ * @property {RegExp|Function} data - content of data element, for example /^[^\s]+/ or function(string){return string.match(/^[^\s]+/)[0];}
+ * @property {String|RegExp|Function} end - end of data element, for example '%>' or /^\?>/ or function(string){return 2;}
+ */
 
 /**
  * Parses the HTML contained in the given file asynchronously.

--- a/src/context.js
+++ b/src/context.js
@@ -1,4 +1,4 @@
-exports.create = function(raw, options, regex) {
+exports.create = function(raw, callbacks, regex) {
 	var index = 0,
 		substring = null;
 
@@ -80,17 +80,40 @@ exports.create = function(raw, options, regex) {
 	context.callbacks = {};
 	var types = [ 'openElement', 'closeElement', 'attribute', 'comment', 'cdata', 'text', 'docType', 'xmlProlog', 'closeOpenedElement' ];
 	types.forEach(function(value) {
-		context.callbacks[value] = options[value] || function() {
-		};
+		context.callbacks[value] = function() {};
 	});
+
+	callbacks = callbacks || {};
+	for (var name in callbacks) {
+		context.callbacks[name] = callbacks[name];
+	}
 
 	context.regex = {
 		name: /[a-zA-Z_][\w:\-\.]*/,
-		attribute: /[a-zA-Z_][\w:\-\.]*/
+		attribute: /[a-zA-Z_][\w:\-\.]*/,
+		dataElements: {
+			cdata: {
+				start: '![CDATA[',
+				end: ']]>'
+			},
+			comment: {
+				start: '!--',
+				end: '-->'
+			},
+			docType: {
+				start: '!DOCTYPE ',
+				end: '>',
+				caseInsensitive: true
+			}
+		}
 	};
+
 	regex = regex || {};
 	for (var name in regex) {
-		if (regex.hasOwnProperty(name)) {
+		if (name === 'dataElements') {
+			Object.assign(context.regex.dataElements, regex.dataElements);
+		}
+		else {
 			context.regex[name] = regex[name];
 		}
 	}

--- a/src/context.js
+++ b/src/context.js
@@ -1,10 +1,12 @@
 exports.create = function(raw, options, regex) {
-	var index = 0;
+	var index = 0,
+		substring = null;
+
 	var context = {
 		text: '',
 		peek: function(count) {
 			count = count || 1;
-			return this.raw.substr(index + 1, count);
+			return this.raw.substr(this.index + 1, count);
 		},
 		read: function(count) {
 			if (count === 0) {
@@ -12,9 +14,9 @@ exports.create = function(raw, options, regex) {
 			}
 			count = count || 1;
 			var next = this.peek(count);
-			index += count;
-			if (index > this.length) {
-				index = this.length;
+			this.index += count;
+			if (this.index > this.length) {
+				this.index = this.length;
 			}
 			return next;
 		},
@@ -31,11 +33,11 @@ exports.create = function(raw, options, regex) {
 			return value;
 		},
 		isEof: function() {
-			return index >= this.length;
+			return this.index >= this.length;
 		},
 		readRegex: function(regex) {
 			var value = (regex.exec(this.raw.substring(this.index)) || [''])[0];
-			index += value.length;
+			this.index += value.length;
 			return value;
 		},
 		peekIgnoreWhitespace: function(count) {
@@ -67,8 +69,12 @@ exports.create = function(raw, options, regex) {
 	context.__defineGetter__('index', function() {
 		return index;
 	});
+	context.__defineSetter__('index', function(value) {
+		index = value;
+		substring = null;
+	});
 	context.__defineGetter__('substring', function() {
-		return this.raw.substring(this.index);
+		return substring === null ? (substring = this.raw.substring(this.index)) : substring;
 	});
 
 	context.callbacks = {};

--- a/tests/dataelement-tests.js
+++ b/tests/dataelement-tests.js
@@ -1,0 +1,73 @@
+var should = require('should');
+var helpers = require('./helpers');
+
+describe('dataElement', function () {
+    it('at beginning of document', function() {
+        var dataCount = 0;
+        helpers.parseString('<?php echo "<html></html>" ?>', {
+            php: function(value) {
+                value.should.equal(' echo "<html></html>" ');
+                dataCount++;
+            }
+        }, {
+            dataElements: {
+                php: {
+                    start: '?php',
+                    end: '?>'
+                }
+            }
+        });
+
+        dataCount.should.equal(1);
+    });
+
+    it('in middle of document', function() {
+        var dataCount = 0, openCount = 0, closeCount = 0;
+        helpers.parseString('<foo><?= "<div>$var</div>" ?></foo>', {
+            openElement: function(name) {
+                name.should.equal('foo');
+                openCount++;
+            },
+            closeElement: function(name) {
+                name.should.equal('foo');
+                closeCount++;
+            },
+            phpEcho: function(value) {
+                openCount.should.equal(1);
+                closeCount.should.equal(0);
+                value.should.equal(' "<div>$var</div>" ');
+                dataCount++;
+            }
+        }, {
+            dataElements: {
+                phpEcho: {
+                    start: '?=',
+                    end: '?>'
+                }
+            }
+        });
+
+        dataCount.should.equal(1);
+        openCount.should.equal(1);
+        closeCount.should.equal(1);
+    });
+
+    it('with line breaks', function() {
+        var dataCount = 0;
+        helpers.parseString('<?php\nfoo\n?>', {
+            php: function(value) {
+                value.should.equal('\nfoo\n');
+                dataCount++;
+            }
+        }, {
+            dataElements: {
+                php: {
+                    start: '?php',
+                    end: '?>'
+                }
+            }
+        });
+
+        dataCount.should.equal(1);
+    });
+});

--- a/tests/dataelement-tests.js
+++ b/tests/dataelement-tests.js
@@ -2,7 +2,7 @@ var should = require('should');
 var helpers = require('./helpers');
 
 describe('dataElement', function () {
-    it('at beginning of document', function() {
+    it('as string', function() {
         var dataCount = 0;
         helpers.parseString('<?php echo "<html></html>" ?>', {
             php: function(value) {
@@ -12,7 +12,7 @@ describe('dataElement', function () {
         }, {
             dataElements: {
                 php: {
-                    start: '?php',
+                    start: '<?php',
                     end: '?>'
                 }
             }
@@ -21,7 +21,7 @@ describe('dataElement', function () {
         dataCount.should.equal(1);
     });
 
-    it('in middle of document', function() {
+    it('as regex', function() {
         var dataCount = 0, openCount = 0, closeCount = 0;
         helpers.parseString('<foo><?= "<div>$var</div>" ?></foo>', {
             openElement: function(name) {
@@ -41,8 +41,8 @@ describe('dataElement', function () {
         }, {
             dataElements: {
                 phpEcho: {
-                    start: '?=',
-                    end: '?>'
+                    start: /^<\?=/,
+                    end: /\?>/
                 }
             }
         });
@@ -52,22 +52,44 @@ describe('dataElement', function () {
         closeCount.should.equal(1);
     });
 
-    it('with line breaks', function() {
+    it('as function', function() {
         var dataCount = 0;
-        helpers.parseString('<?php\nfoo\n?>', {
+        helpers.parseString('<!-- test --><?php\nfoo\n?>', {
+            comment: function (value) {
+                value.should.equal(' test ');
+                dataCount++;
+            },
             php: function(value) {
-                value.should.equal('\nfoo\n');
+                value.should.deepEqual({
+                    value: '\nfoo\n',
+                    length: '\nfoo\n'.length
+                });
                 dataCount++;
             }
         }, {
             dataElements: {
                 php: {
-                    start: '?php',
-                    end: '?>'
+                    start: function (substring) {
+                        return substring.slice(0, 5) === '<?php' ? 5 : -1;
+                    },
+                    data: function (substring) {
+                        substring.should.equal('\nfoo\n?>');
+                        dataCount++;
+                        var index = substring.indexOf('?>');
+                        return {
+                            value: substring.slice(0, index),
+                            length: substring.slice(0, index).length
+                        };
+                    },
+                    end: function (substring) {
+                        substring.should.equal('?>');
+                        dataCount++;
+                        return 2;
+                    }
                 }
             }
         });
 
-        dataCount.should.equal(1);
+        dataCount.should.equal(4);
     });
 });


### PR DESCRIPTION
How about to give user an ability to parse data elements like doctype or comment where element starts with `<` and after that some custom code for example 
```javascript
helpers.parseString('<foo><?= "<div>$var</div>" ?></foo>', {
    phpEcho: function(value) {
        value.should.equal(' "<div>$var</div>" ');
    }
}, {
    dataElements: {
        phpEcho: {
            start: '?=',
            end: '?>'
        }
    }
});
```
If you look into code you will see that I rewrited docType, comment and cdata, now they also part or `context.regex` and can be configurable.

This feature will help to parse php, underscore and some other templates.