### PR TITLE
Add support for Javascript Template (JST) files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "html-parser",
-	"version": "0.10.1",
+	"version": "0.11.0",
 	"description": "HTML/XML parser with less explosions",
 	"keywords": [ "html", "xml", "parser", "explosion" ],
 	"author": {
@@ -14,7 +14,8 @@
 	"contributors": [
 		{ "name": "jdponomarev" },
 		{ "name": "fiatjaf" },
-		{ "name": "Sergii Kliuchnyk" }
+		{ "name": "Sergii Kliuchnyk" },
+		{ "name": "Edwin Hoogerbeets" }
 	],
 
 	"main": "./src/parser.js",

--- a/src/parser.js
+++ b/src/parser.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 
 function readAttribute(context) {
 	var name = context.readRegex(context.regex.attribute);
-	var value = null, quote = '"';
+	var value = null, quote = '';
 	if (context.current === '=' || context.peekIgnoreWhitespace() === '=') {
 		context.readRegex(/\s*=\s*/);
 		var attributeValueRegex;
@@ -14,6 +14,7 @@ function readAttribute(context) {
 			break;
 		case '"':
 			attributeValueRegex = /("(\\"|<%.*?%>|[^"])*?")/;
+			quote = '"';
 			break;
 		case '<':
 			attributeValueRegex = (context.peek() === '%') ? 

--- a/tests/attribute-tests.js
+++ b/tests/attribute-tests.js
@@ -29,9 +29,10 @@ describe('attributes', function() {
 				openCount++;
 			},
 
-			attribute: function(name, value) {
+			attribute: function(name, value, quote) {
 				name.should.equal('bar');
 				value.should.equal('baz');
+				quote.should.equal('"');
 				attrCount++;
 			}
 		});
@@ -48,9 +49,10 @@ describe('attributes', function() {
 				openCount++;
 			},
 
-			attribute: function(name, value) {
+			attribute: function(name, value, quote) {
 				name.should.equal('bar');
 				value.should.equal('baz');
+				quote.should.equal("'");
 				attrCount++;
 			}
 		});
@@ -105,9 +107,10 @@ describe('attributes', function() {
 				openCount++;
 			},
 
-			attribute: function(name, value) {
+			attribute: function(name, value, quote) {
 				name.should.equal(attrCount === 0 ? 'width' : 'height');
 				value.should.equal(attrCount === 0 ? '0' : '12');
+				quote.should.equal('"');
 				attrCount++;
 			}
 		});
@@ -124,9 +127,10 @@ describe('attributes', function() {
 				openCount++;
 			},
 
-			attribute: function(name, value) {
+			attribute: function(name, value, quote) {
 				name.should.equal('bar');
 				value.should.equal('baz');
+				quote.should.equal('"');
 				attrCount++;
 			}
 		});
@@ -143,9 +147,10 @@ describe('attributes', function() {
 				openCount++;
 			},
 
-			attribute: function(name, value) {
+			attribute: function(name, value, quote) {
 				name.should.equal('bar');
 				value.should.equal('baz');
+				quote.should.equal('"');
 				attrCount++;
 			}
 		});
@@ -162,9 +167,10 @@ describe('attributes', function() {
 				openCount++;
 			},
 
-			attribute: function(name, value) {
+			attribute: function(name, value, quote) {
 				name.should.equal('bar:baz');
 				value.should.equal('bat');
+				quote.should.equal('"');
 				attrCount++;
 			}
 		});
@@ -181,9 +187,10 @@ describe('attributes', function() {
 				openCount++;
 			},
 
-			attribute: function(name, value) {
+			attribute: function(name, value, quote) {
 				name.should.equal('[bar]');
 				value.should.equal('baz');
+				quote.should.equal('"');
 				attrCount++;
 			}
 		}, {

--- a/tests/attribute-tests.js
+++ b/tests/attribute-tests.js
@@ -110,7 +110,7 @@ describe('attributes', function() {
 			attribute: function(name, value, quote) {
 				name.should.equal(attrCount === 0 ? 'width' : 'height');
 				value.should.equal(attrCount === 0 ? '0' : '12');
-				quote.should.equal('"');
+				quote.should.equal(attrCount === 0 ? '' : '"');
 				attrCount++;
 			}
 		});

--- a/tests/files/good-expected.html
+++ b/tests/files/good-expected.html
@@ -7,13 +7,24 @@
 		<link rel="shortcut icon" type="image/png" href="/favicon.ico"/>
 	</head>
 
+    <style>
+    /* comment with tricky <tags> embedded <in> it */
+	.header {
+	   font: "Lucida Sans";
+	   size: 14pt;
+	}
+
+	div>child-selector {
+		background-color: yellow;
+	}
+    </style>
 	<body>
 		<div id="wrapper">
 			<div id="header">
 				<h1><a href="/"><span>t</span>ommy <span>mont</span>gomery</a></h1>
 			</div>
 
-			<div id="main-content">
+			<div id='single-quote-class'>
 				<div id="menu"></div>
 			</div>
 		</div>

--- a/tests/files/good-expected.html
+++ b/tests/files/good-expected.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<title>tommy montgomery </title>
-		<meta foo="bar" http-equiv="content-type" content="text/html;charset=utf-8"/>
+		<meta foo=bar http-equiv="content-type" content="text/html;charset=utf-8"/>
 		<link rel="stylesheet" href="/media/css/global.css"/>
 		<link rel="shortcut icon" type="image/png" href="/favicon.ico"/>
 	</head>

--- a/tests/files/good.html
+++ b/tests/files/good.html
@@ -10,13 +10,24 @@
 			href="/favicon.ico"/>
 	</head>
 
+    <style>
+    /* comment with tricky <tags> embedded <in> it */
+	.header {
+	   font: "Lucida Sans";
+	   size: 14pt;
+	}
+
+	div>child-selector {
+		background-color: yellow;
+	}
+    </style>
 	<body>
 		<div id="wrapper">
 			<div id="header">
 				<h1><a href="/"><span>t</span>ommy <span>mont</span>gomery</a></h1>
 			</div>
 
-			<div id="main-content">
+			<div id='single-quote-class'>
 				<div id="menu"></div>
 			</div>
 		</div>

--- a/tests/sanitization-tests.js
+++ b/tests/sanitization-tests.js
@@ -160,7 +160,7 @@ describe('Sanitization', function() {
 	it('should sanitize based on attribute value', function() {
 		var html = '<foo id="abc"></foo><foo id="def"></foo>';
 		var sanitized = helpers.parser.sanitize(html, {
-			attributes: function(name, value) {
+			attributes: function(name, value, quote) {
 				return value === 'abc';
 			}
 		});

--- a/tests/xml-prolog-tests.js
+++ b/tests/xml-prolog-tests.js
@@ -8,7 +8,7 @@ describe('XML Prologs', function() {
 			xmlProlog: function() {
 				prologCount++;
 			},
-			attribute: function(name, value) {
+			attribute: function(name, value, quote) {
 				name.should.equal('version');
 				value.should.equal('1.0');
 				attributeCount++;
@@ -64,7 +64,7 @@ describe('XML Prologs', function() {
 				name.should.equal('foo');
 				closeCount++;
 			},
-			attribute: function(name, value) {
+			attribute: function(name, value, quote) {
 				openCount.should.equal(1);
 				closeCount.should.equal(0);
 				name.should.equal('version');


### PR DESCRIPTION
1. Support the syntax of EJS or EmbeddedJS JST files. See http://ejs.co or http://www.embeddedjs.com

2. Also, made a change to skip style tags in the same way that script and xmp tags are skipped. Some valid CSS syntax or stuff inside of /* comments */ that appear inside of style tags cause HTML parsing errors.

3. Now pass the quote into the attribute callback. That way, the original HTML can be recreated if needed. This allowed me to avoid thousands of diffs between the English JST files and the localized ones where there was no actual logic change, just quote style differences. This obscured the actual translations in the diff output, making for horrendously tedious reviews. 